### PR TITLE
Align sync and async structures

### DIFF
--- a/Session1_AsyncAwait/SyncVsAsyncDemos.cs
+++ b/Session1_AsyncAwait/SyncVsAsyncDemos.cs
@@ -42,9 +42,10 @@ public static class SyncVsAsyncDemos
         // Esta llamada NO bloquea el hilo principal. Lo libera.
         var rutaArchivo = await DescargarArchivoAsincronoAsync();
 
+        await actividadTask;
+
         var info = new FileInfo(rutaArchivo);
         Console.WriteLine($"\nDescarga asíncrona completada. Archivo guardado en {info.FullName} ({info.Length} bytes).");
-        await actividadTask;
     }
 
     private static string DescargarArchivoSincrono()


### PR DESCRIPTION
## Summary
- ensure both download demos share the same structure
- start activity dots before calling each download to highlight sync blocking

## Testing
- `dotnet build Session1_AsyncAwait/Session1_AsyncAwait.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b49f2be3c832cb020dfaa3bb6a276